### PR TITLE
Fix outdated noop model implementation

### DIFF
--- a/src/models/NoopImageModel.php
+++ b/src/models/NoopImageModel.php
@@ -21,7 +21,7 @@ use Imagine\Image\Box;
 
 use yii\base\InvalidConfigException;
 
-class NoopImageModel implements TransformedImageInterface
+class NoopImageModel extends BaseTransformedImageModel implements TransformedImageInterface
 {
     public $path;
     public $filename;


### PR DESCRIPTION
Fixes this error:

```
PHP Fatal Error &#039;yii\base\ErrorException&#039; with message &#039;Class spacecatninja\imagerx\models\NoopImageModel contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (spacecatninja\imagerx\models\TransformedImageInterface::getPlaceholder)&#039; 

in /app/user/vendor/spacecatninja/imager-x/src/models/NoopImageModel.php:24
```