### PR TITLE
Fix an issue where the S3 storage path may have a blank initial dir

### DIFF
--- a/src/externalstorage/AwsStorage.php
+++ b/src/externalstorage/AwsStorage.php
@@ -57,11 +57,14 @@ class AwsStorage implements ImagerStorageInterface
         }
         
         if (isset($settings['folder']) && $settings['folder'] !== '') {
-            $uri = ltrim(FileHelper::normalizePath($settings['folder'].'/'.$uri), '/');
+            $uri = FileHelper::normalizePath($settings['folder'].'/'.$uri);
         }
 
         // Always use forward slashes for S3
         $uri = str_replace('\\', '/', $uri);
+
+        // Dont start with forward slashes
+        $uri = ltrim($uri, '/');
 
         $opts = $settings['requestHeaders'] ?? [];
         $cacheDuration = $isFinal ? $config->cacheDurationExternalStorage : $config->cacheDurationNonOptimized;


### PR DESCRIPTION
I had an issue where if my `folder` S3 config setting was set to `null`, `""`, or not set, the images would be saved to S3 with the first folder blank. This would create paths with a double slash, for example:
https://cms-dev-craft-assets-origin.s3.amazonaws.com//images/58/IMG_4747_2020-09-10-050823_73805955f84e1e8cdc39785ef8520bd7.jpg

S3 requires an exact match, so removing the double slash results in an error:
https://cms-dev-craft-assets-origin.s3.amazonaws.com/images/58/IMG_4747_2020-09-10-050823_73805955f84e1e8cdc39785ef8520bd7.jpg

As a workaround, I figured out that I can set `folder` to `/`. This triggers the left trimming of all slashes.

This PR is a permanent fix to always left trim forward slashes even if not using the `folder` setting.