### PR TITLE
Catches AssetException that can occur, and rethrows as ImagerException

### DIFF
--- a/src/models/LocalSourceImageModel.php
+++ b/src/models/LocalSourceImageModel.php
@@ -16,6 +16,7 @@ use craft\base\LocalVolumeInterface;
 use craft\base\Volume;
 use craft\helpers\FileHelper;
 use craft\elements\Asset;
+use craft\errors\AssetException;
 use craft\helpers\StringHelper;
 use craft\helpers\Assets as AssetsHelper;
 


### PR DESCRIPTION
This allows us to suppress these types of exceptions that might occur from a missing image, using the `suppressExceptions` config setting.