### PR TITLE
Use getGeneral() method when calling getConfig()

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -195,6 +195,6 @@ class Settings extends Model
     public function init()
     {
         // Set default based on devMode. Overridable through config.  
-        $this->suppressExceptions = !\Craft::$app->getConfig()->general->devMode;
+        $this->suppressExceptions = !\Craft::$app->getConfig()->getGeneral()->devMode;
     }
 }


### PR DESCRIPTION
This is just for a consistency or coding standards/guidelines. Using the public method of getGeneral() when using getConfig(). It has no functional difference other than following the best practice of using the public get methods in PHP which (I think) is the preferred PHP coding guidelines generally.

I recently did a scan in a project and it happened to pick up this in the vendor folder results.

You can of course tell me this isn't really a problem, but just in case you are cool with it. Feel free to merge!