### PR TITLE
Feature/transform event - Fixes #155

### DIFF
--- a/src/events/TransformImageEvent.php
+++ b/src/events/TransformImageEvent.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Imager X plugin for Craft CMS
+ *
+ * Ninja powered image transforms.
+ *
+ * @link      https://www.spacecat.ninja
+ * @copyright Copyright (c) 2022 André Elvan
+ */
+
+namespace spacecatninja\imagerx\events;
+
+use yii\base\Event;
+use craft\elements\Asset;
+use spacecatninja\imagerx\models\TransformedImageInterface;
+
+class TransformImageEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string|Asset Image being transformed
+     */
+    public string|Asset $image;
+
+    /**
+     * @var array Transform params given to Imager-X (normalized)
+     */
+    public array $transforms = [];
+
+    /**
+     * @var bool Whether the image transform operation should be considered valid
+     *  and Imager-X should proceed
+     */
+    public bool $isValid = true;
+
+    /**
+     * @var TransformedImageInterface|TransformedImageInterface[]|null Resulting (list of) transformed images
+     */
+    public array|TransformedImageInterface|null $transformedImages = null;
+}


### PR DESCRIPTION
Adds triggering of an `EVENT_BEFORE_TRANSFORM_IMAGE` event inside `ImagerService::transformImage()`, which mirrors Craft's built-in `EVENT_BEFORE_GENERATE_TRANSFORM` event as much as possible and enables similar intervention from inside modules/plugins, i.e. a) override the transform result or b) cancel the transform all together.

The main purpose is to be more consistent with Craft's built-in transforms such that modules/plugins that rely on the built-in events can also support projects which use Imager-X.

The triggered `TransformImageEvent` event is triggered before the Imager-X transformer is invoked. It has the following properties:
- `image` the image url (string) or model (Asset element) being transformed
- `transforms` the transform parameters that were given to Imager-X (normalized and resolved)
- `transformedImages` which is `null` but can be set to a `TransformedImageModel` or list of `TransformedImageModel`s, in which case those will be returned by `ImagerService::transformImage()` directly and the image transformer will not be invoked.
- `isValid` boolean which can be set to `false` in order to cancel the transform (`ImagerService::transformImage()` will return `null`)

**Important**: since the event could be used to reproduce the Imager-X Pro feature of custom image transformers on the Imager-X Lite edition, overriding the transform results by setting the event's `transformedImages` property is limited to the Pro edition only.  

For convenience and to enable other use-cases this PR also adds triggering of a `EVENT_AFTER_TRANSFORM_IMAGE` event if the transform was **not cancelled** and **no exception** was thrown. Note that in this PR the after transform event is triggered even if the transform's *result is `null`*, but that might not be desired behavior and could easily be changed.