### PR TITLE
Fix error when unable to get image size

### DIFF
--- a/src/helpers/ImagerHelpers.php
+++ b/src/helpers/ImagerHelpers.php
@@ -206,7 +206,7 @@ class ImagerHelpers
         // Try getimagesize first
         $sourceImageInfo = @getimagesize($source->getFilePath());
 
-        if ($sourceImageInfo[0] !== 0 && $sourceImageInfo[1] !== 0) {
+        if ($sourceImageInfo && $sourceImageInfo[0] !== 0 && $sourceImageInfo[1] !== 0) {
             return array_slice($sourceImageInfo, 0, 2);
         }
 


### PR DESCRIPTION
getimagesize can return `false` as value, breaking the following if because it tries to acces an array