### PR TITLE
Fixed an issue where images with NULL dimensions caused Imgix transformer to throw an exception

### DIFF
--- a/src/models/ImgixTransformedImageModel.php
+++ b/src/models/ImgixTransformedImageModel.php
@@ -74,7 +74,7 @@ class ImgixTransformedImageModel extends BaseTransformedImageModel implements Tr
                 $paramsW = (int)$params['w'];
                 $paramsH = (int)$params['h'];
 
-                if ($sourceWidth !== 0 && $sourceHeight !== 0) {
+                if ($sourceWidth !== 0 && $sourceHeight !== 0 && $sourceWidth !== NULL && $sourceHeight !== NULL) {
                     if ($sourceWidth / $sourceHeight > $paramsW / $paramsH) {
                         $useW = min($paramsW, $sourceWidth);
                         $this->width = $useW;


### PR DESCRIPTION
Occasionally on a few recent builds, I'll get an asset that gets uploaded to Craft with NULL dimensions set in the database. This causes the following error...

```[DivisionByZeroError] DivisionByZeroError: Division by zero in /var/www/vendor/spacecatninja/imager-x/src/models/ImgixTransformedImageModel.php:78```