### PR TITLE
Return original value when no image or not safe

### DIFF
--- a/src/gql/directives/ImagerSrcset.php
+++ b/src/gql/directives/ImagerSrcset.php
@@ -81,7 +81,7 @@ class ImagerSrcset extends Directive
         }
         
         if ($source->kind !== 'image' || !\in_array(strtolower($source->getExtension()), ImagerService::getConfig()->safeFileFormats, true)) {
-            return null;
+            return $value;
         }
         
         try {

--- a/src/gql/directives/ImagerTransform.php
+++ b/src/gql/directives/ImagerTransform.php
@@ -86,7 +86,7 @@ class ImagerTransform extends Directive
         $transform = $arguments['handle'] ?? $arguments;
         
         if ($source->kind !== 'image' || !\in_array(strtolower($source->getExtension()), ImagerService::getConfig()->safeFileFormats, true)) {
-            return null;
+            return $value;
         }
         
         try {

--- a/src/gql/resolvers/ImagerResolver.php
+++ b/src/gql/resolvers/ImagerResolver.php
@@ -55,7 +55,7 @@ class ImagerResolver extends Resolver
         }
         
         if ($asset instanceof Asset && ($asset->kind !== 'image' || !\in_array(strtolower($asset->getExtension()), ImagerService::getConfig()->safeFileFormats, true))) {
-            return null;
+            return $asset;
         }
         
         if ($asset !== null) {


### PR DESCRIPTION
An example of usage is when you don't want to transform SVG images at all. If you keep SVG out of the safe file formats, it won't touch them but still return the original SVG.