### PR TITLE
Fix wrong asset url for external volumes

### DIFF
--- a/src/models/LocalSourceImageModel.php
+++ b/src/models/LocalSourceImageModel.php
@@ -145,7 +145,7 @@ class LocalSourceImageModel
             if (!$this->isValidFile($this->getFilePath()) || (($config->cacheDurationRemoteFiles !== false) && ((FileHelper::lastModifiedTime($this->getFilePath()) + $config->cacheDurationRemoteFiles) < time()))) {
                 if ($this->asset && $this->type === 'volume') {
                     try {
-                        $fs = $this->asset->getVolume()->getFs();
+                        $fs = $this->asset->getVolume();
                     } catch (InvalidConfigException $invalidConfigException) {
                         Craft::error($invalidConfigException->getMessage(), __METHOD__);
                         throw new ImagerException($invalidConfigException->getMessage(), $invalidConfigException->getCode(), $invalidConfigException);
@@ -248,7 +248,7 @@ class LocalSourceImageModel
         }
 
         try {
-            $this->url = AssetsHelper::generateUrl($image->getVolume()->getFs(), $image);
+            $this->url = AssetsHelper::generateUrl($image->getVolume(), $image);
             $this->path = FileHelper::normalizePath($runtimeImagerPath.$this->transformPath.'/');
             $this->filename = $image->getFilename();
             $this->basename = $image->getFilename(false);


### PR DESCRIPTION
As in Craft 5 the subpath is moved to the volumes, we should pass the Volume instead of the Filesystem to the `generateUrl` function