### PR TITLE
Perform URL transform before native transforms

### DIFF
--- a/src/ImagerX.php
+++ b/src/ImagerX.php
@@ -241,7 +241,7 @@ class ImagerX extends Plugin
                 // Check if the asset is an image before proceeding
                 if ($event->asset->kind === 'image') {
                     ImagerX::$plugin->imagerx->removeTransformsForAsset($event->asset);
-    
+
                     // If Imgix purging is possible, do that too
                     if ($config->imgixEnableAutoPurging && ImgixService::getCanPurge()) {
                         ImagerX::$plugin->imgix->purgeAssetFromImgix($event->asset);
@@ -334,7 +334,7 @@ class ImagerX extends Plugin
                         }
                     }
                 }
-                
+
                 $event->actions[] = ClearTransformsElementAction::class;
 
                 if (ImagerX::getInstance()?->is(ImagerX::EDITION_PRO)) {
@@ -363,7 +363,7 @@ class ImagerX extends Plugin
 
         // Event listener for overriding Craft's internal transform functionality
         if ($config->useForNativeTransforms) {
-            Event::on(Asset::class, Asset::EVENT_DEFINE_URL,
+            Event::on(Asset::class, Asset::EVENT_BEFORE_DEFINE_URL,
                 static function(DefineAssetUrlEvent $event) {
                     if ($event->transform !== null && $event->sender->kind === 'image' && \in_array(strtolower($event->sender->getExtension()), ImagerService::getConfig()->safeFileFormats, true)) {
                         try {
@@ -395,6 +395,7 @@ class ImagerX extends Plugin
 
                                 if ($transformedImage !== null) {
                                     $event->url = $transformedImage->getUrl();
+                                    $event->handled = true;
                                 }
                             }
                         } catch (ImagerException $e) {


### PR DESCRIPTION
Switches to using `Asset::EVENT_BEFORE_DEFINE_URL` when `useForNativeTransforms` is true to prevent native Craft transforms from running prior to ImagerX transforms.

Craft will [run native transforms](https://github.com/craftcms/cms/blob/82c9aefff15935552c094cff1a55c0c45a7a15d5/src/elements/Asset.php#L2170-L2172) if the url is null and the event hasn't been marked as handled. 

Before this change, the native transforms would run, and then the Imager X logic would run.